### PR TITLE
FIX #2 - comply to original file names when downloading onesky translations

### DIFF
--- a/lib/onesky/rails/file_client.rb
+++ b/lib/onesky/rails/file_client.rb
@@ -52,19 +52,14 @@ NOTICE
         DIR_PREFIX + locale
       end
 
-      def extract_file_name(header_hash)
-        search_text = 'filename='
-        if disposition = header_hash[:content_disposition]
-          if idx = disposition.index(search_text)
-            disposition[(idx + search_text.length)..-1]
-          end
-        end
-      end
-
       def make_translation_dir(dir_path, locale)
         target_path = File.join(dir_path, locale_dir(locale))
         Dir.mkdir(target_path) unless File.directory?(target_path)
         target_path
+      end
+
+      def locale_file_name(file, to_locale)
+        file.sub(@base_locale.to_s, to_locale)
       end
 
       def get_default_locale_files(string_path)
@@ -76,7 +71,8 @@ NOTICE
 
       def save_translation(response, string_path, locale, file)
         locale_path = make_translation_dir(string_path, locale)
-        target_file = extract_file_name(response.headers) || file
+        target_file = locale_file_name(file, locale)
+
         File.open(File.join(locale_path, target_file), 'w') do |f|
           f.write(TRANSLATION_NOTICE + response.body.force_encoding(ENCODING))
         end

--- a/onesky-rails.gemspec
+++ b/onesky-rails.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 3.1.0"
+  spec.add_development_dependency "timecop", "~> 0.7.0"
   spec.add_development_dependency "webmock", "~> 1.19.0"
 end

--- a/spec/fixtures/locales/special_en.yml
+++ b/spec/fixtures/locales/special_en.yml
@@ -1,0 +1,2 @@
+en:
+  some: thing

--- a/spec/onesky/rails/file_client_spec.rb
+++ b/spec/onesky/rails/file_client_spec.rb
@@ -10,24 +10,21 @@ describe Onesky::Rails::FileClient do
   end
 
   context '#upload' do
-    it 'strings to onesky' do
+    it 'all translation files to onesky' do
       stub_request(:post, full_path_with_auth_hash("/projects/#{config_hash['project_id']}/files", config_hash['api_key'], config_hash['api_secret']))
         .to_return(status: 201)
 
-      expect(client.upload(file_path)).to eq(["#{file_path}/en.yml"])
+      expect(client.upload(file_path)).to eq(["#{file_path}/en.yml","#{file_path}/special_en.yml"])
     end
   end
 
   context 'download' do
 
-    let(:file_name) {'ja.yml'}
-    let(:response_headers) do
-      {
-        'Content-Type'        => 'text/plain',
-        'Content-Disposition' => "attachment; filename=#{file_name}",
-      }
+    let(:expected_locale_files) do
+      ["#{locale_dir}/ja.yml", "#{locale_dir}/special_ja.yml"]
     end
-    let(:query_string) {'&source_file_name=en.yml&locale=ja'}
+
+    let(:file_names) {['en.yml', 'special_en.yml']}
 
     def locale_dir
       File.join(file_path, 'onesky_ja')
@@ -53,16 +50,29 @@ describe Onesky::Rails::FileClient do
     end
 
     it 'download translations from OneSky and save as YAML files' do
-      stub_request(:get, full_path_with_auth_hash("/projects/#{config_hash['project_id']}/translations", config_hash['api_key'], config_hash['api_secret']) + query_string)
-        .to_return(
-          status: 200,
-          body: File.read(File.join(file_path, file_name)),
-          headers: response_headers)
+      prepare_download_requests!
 
       expect(locale_files).to be_empty
       client.download(file_path)
-      expect(locale_files).to eq(["#{locale_dir}/#{file_name}"])
+      expect(locale_files).to eq(expected_locale_files)
     end
+
+    def prepare_download_requests!
+      Timecop.freeze
+      file_names.each do |file_name|
+        response_headers = {
+          'Content-Type'        => 'text/plain',
+          'Content-Disposition' => "attachment; filename=#{file_name}",
+        }
+        query_string = "&source_file_name=#{file_name}&locale=ja"
+        stub_request(:get, full_path_with_auth_hash("/projects/#{config_hash['project_id']}/translations", config_hash['api_key'], config_hash['api_secret']) + query_string)
+          .to_return(
+            status: 200,
+            body: File.read(File.join(file_path, file_name)),
+            headers: response_headers)
+      end
+    end
+
   end
 
 end

--- a/spec/onesky/rails/file_client_spec.rb
+++ b/spec/onesky/rails/file_client_spec.rb
@@ -14,7 +14,7 @@ describe Onesky::Rails::FileClient do
       stub_request(:post, full_path_with_auth_hash("/projects/#{config_hash['project_id']}/files", config_hash['api_key'], config_hash['api_secret']))
         .to_return(status: 201)
 
-      expect(client.upload(file_path)).to eq(["#{file_path}/en.yml","#{file_path}/special_en.yml"])
+      expect(client.upload(file_path)).to match_array(["#{file_path}/en.yml","#{file_path}/special_en.yml"])
     end
   end
 
@@ -54,7 +54,7 @@ describe Onesky::Rails::FileClient do
 
       expect(locale_files).to be_empty
       client.download(file_path)
-      expect(locale_files).to eq(expected_locale_files)
+      expect(locale_files).to match_array(expected_locale_files)
     end
 
     def prepare_download_requests!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'webmock/rspec'
 require 'i18n'
 require 'onesky/rails'
 require 'onesky'
+require 'timecop'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
This is related to issue #2 