### PR TITLE
Allow passing base locale in config hash

### DIFF
--- a/lib/onesky/rails/client.rb
+++ b/lib/onesky/rails/client.rb
@@ -15,7 +15,7 @@ module Onesky
         @client = ::Onesky::Client.new(@config['api_key'], @config['api_secret'])
         @client.plugin_code = 'rails-string'
         @project = @client.project(@config['project_id'].to_i)
-        @base_locale = ::I18n.default_locale
+        @base_locale = config_hash.fetch('base_locale', ::I18n.default_locale)
         @onesky_locales = []
       end
 

--- a/spec/onesky/rails/client_spec.rb
+++ b/spec/onesky/rails/client_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Onesky::Rails::Client do
+  let(:config_hash) { create_config_hash }
 
   describe '#new' do
 
@@ -30,6 +31,17 @@ describe Onesky::Rails::Client do
       it 'to retrieve languages activated at OneSky' do
         expect{client.verify_languages!}.to_not raise_error
         expect(client.onesky_locales).to eq(['ja'])
+      end
+
+      context 'with explicit base locale and different default locale' do
+        let(:config_hash) { create_config_hash.merge({'base_locale' => 'en'}) }
+
+        it 'to retrieve languages activated at OneSky' do
+          I18n.default_locale = :ja
+
+          expect{client.verify_languages!}.to_not raise_error
+          expect(client.onesky_locales).to eq(['ja'])
+        end
       end
     end
 

--- a/spec/onesky/rails/file_client_spec.rb
+++ b/spec/onesky/rails/file_client_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Onesky::Rails::FileClient do
 
+  let(:config_hash) { create_config_hash }
   let(:client) {Onesky::Rails::FileClient.new(config_hash)}
   let(:file_path) { File.expand_path("../../../fixtures/locales", __FILE__) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ def languages_response
   }
 end
 
-def config_hash
+def create_config_hash
   {
     "api_key" => 'fakeapi',
     "api_secret" => 'fakesecret',


### PR DESCRIPTION
We had a use case where the base locale was different from the default locale. We use `en` for our phrases 'spec' and `en-GB` as the default locale for our website.

The `Onesky::Client` currently uses `::I18n.default_locale` as its `base_locale`, and we could find no acceptable way to change this outside of the gem.

Our solution allows `base_locale` to be passed in with the config hash.