### PR TITLE
Invalid rails locale translation

### DIFF
--- a/lib/onesky/rails/client.rb
+++ b/lib/onesky/rails/client.rb
@@ -22,7 +22,7 @@ module Onesky
       def verify_languages!
         languages = get_languages_from_onesky!
         languages.each do |language|
-          locale = language['custom_locale'] || to_rails_locale(language['code'])
+          locale = language['custom_locale'] || language['code']
           if (language['is_base_language'])
             verify_base_locale!(locale)
           else

--- a/lib/onesky/rails/file_client.rb
+++ b/lib/onesky/rails/file_client.rb
@@ -59,7 +59,7 @@ NOTICE
       end
 
       def locale_file_name(file, to_locale)
-        file.sub(@base_locale.to_s, to_locale)
+        file.sub(to_rails_locale(@base_locale.to_s), to_locale)
       end
 
       def get_default_locale_files(string_path)


### PR DESCRIPTION
There is a problem with composed locale names (i.e. en-US). With the current code it is necessary to set the default_locale to en_US which is an invalid locale for rails.

I move the locale translation to the file_client which is the component who really need to translate en-US to en_US