### PR TITLE
Feature/debug option

### DIFF
--- a/lib/generators/onesky/init_generator.rb
+++ b/lib/generators/onesky/init_generator.rb
@@ -7,6 +7,7 @@ module Onesky
       argument :api_key,     :type => :string,  :desc => "API Key"
       argument :api_secret,  :type => :string,  :desc => "API Secret"
       argument :project_id,  :type => :string,  :desc => "Project ID"
+      argument :debug,       :type => :boolean, :desc => "Enable debug info", :default => false
 
       class_option :force,   :type => :boolean, :default => false, :desc => "Overwrite if config file already exists"
 

--- a/lib/generators/templates/onesky.yml.tt
+++ b/lib/generators/templates/onesky.yml.tt
@@ -10,6 +10,7 @@
 api_key: <%= config_hash[:api_key] %>
 api_secret: <%= config_hash[:api_secret] %>
 project_id: <%= config_hash[:project_id] %>
+debug: false
 
 upload:
   is_keeping_all_strings: true

--- a/lib/onesky/rails/client.rb
+++ b/lib/onesky/rails/client.rb
@@ -12,7 +12,7 @@ module Onesky
         end
 
         @config = config_hash
-        @client = ::Onesky::Client.new(@config['api_key'], @config['api_secret'], debug: @config['debug'])
+        @client = initialize_onesky_client
         @client.plugin_code = 'rails-string'
         @project = @client.project(@config['project_id'].to_i)
         @base_locale = config_hash.fetch('base_locale', ::I18n.default_locale)
@@ -44,6 +44,19 @@ module Onesky
       end
 
       private
+
+      #
+      # onesky-ruby version 1.0.1 and lower has only 2 parameters (no options)
+      # while the higer versions have the third parameter.
+      #
+      def initialize_onesky_client
+        if Gem::Version.new(Onesky::VERSION) <= Gem::Version.new('1.0.1')
+          ::Onesky::Client.new(@config['api_key'], @config['api_secret'])
+        else
+          ::Onesky::Client.new(@config['api_key'], @config['api_secret'],
+                               debug: @config['debug'])
+        end
+      end
 
       def is_valid_config!(config)
         config.has_key?('api_key') && config.has_key?('api_secret') && config.has_key?('project_id')

--- a/lib/onesky/rails/client.rb
+++ b/lib/onesky/rails/client.rb
@@ -12,7 +12,7 @@ module Onesky
         end
 
         @config = config_hash
-        @client = ::Onesky::Client.new(@config['api_key'], @config['api_secret'])
+        @client = ::Onesky::Client.new(@config['api_key'], @config['api_secret'], debug: @config['debug'])
         @client.plugin_code = 'rails-string'
         @project = @client.project(@config['project_id'].to_i)
         @base_locale = config_hash.fetch('base_locale', ::I18n.default_locale)
@@ -37,6 +37,10 @@ module Onesky
 
       def to_rails_locale(locale)
         locale.gsub('-', '_')
+      end
+
+      def debug?
+        @config['debug']
       end
 
       private

--- a/lib/onesky/rails/file_client.rb
+++ b/lib/onesky/rails/file_client.rb
@@ -37,6 +37,7 @@ NOTICE
           puts "#{locale_dir(locale)}/"
           onesky_locale = locale.gsub('_', '-')
           files.each do |file|
+            puts "Source file #{file} (locale: #{onesky_locale}) ..." if debug?
             response = @project.export_translation(source_file_name: file, locale: onesky_locale)
             if response.code == 200
               saved_file = save_translation(response, string_path, locale, file)

--- a/onesky-rails.gemspec
+++ b/onesky-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "i18n", ">= 0.5.0"
-  spec.add_dependency "onesky-ruby", "~> 1.0.0"
+  spec.add_dependency "onesky-ruby", "~> 1.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.3"


### PR DESCRIPTION
A debug option has been added to the `onesky-ruby` gem in [this PR](https://github.com/onesky/onesky-ruby/pull/9). This PR is about to pass the value from the `onesky.yml` file to the `onesky-ruby` gem.

It also use the `debug` option in order to show the current file being treated and the locale.