### PR TITLE
Feature/download base or all languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,21 @@ Upload all string files of `I18n.default_locale` to [OneSky](http://www.oneskyap
 ```
 rake onesky:download
 ```
-Download translations of files uploaded in all languages activated in project.
+Download translations of files uploaded in all languages activated in project
+other than the base language.
+
+**Download base language translations**
+```
+rake onesky:download_base
+```
+Download translations of files uploaded only for the base language.
+
+**Download all languages translations**
+```
+rake onesky:download_all
+```
+Download translations of files uploaded for all the languages including the base
+language.
 
 ## TODO
 - Specify file to upload

--- a/lib/onesky/rails/client.rb
+++ b/lib/onesky/rails/client.rb
@@ -19,16 +19,30 @@ module Onesky
         @onesky_locales = []
       end
 
-      def verify_languages!
+      def verify_languages!(options = {})
         languages = get_languages_from_onesky!
         languages.each do |language|
           locale = language['custom_locale'] || to_rails_locale(language['code'])
-          if (language['is_base_language'])
-            verify_base_locale!(locale)
-          else
-            @onesky_locales << locale
-          end
+
+          verify_base_locale!(locale) if language['is_base_language']
+
+          @onesky_locales << locale if allowed_for?(language, options)
         end
+      end
+
+      #
+      # Determine if a language will be used to be downloaded or not.
+      #
+      # With options[:all] == true, all the languages will be used.
+      # With options[:base_only] == true, only the base language of the project
+      # will be used to download tranlsation file.
+      # Otherwise, this method will allow only other languages than the base
+      # language.
+      #
+      def allowed_for?(language, options)
+        return true if options[:all] == true
+        return true if language['is_base_language'] && options[:base_only] == true
+        language['is_base_language'] == false && options[:base_only] == false
       end
 
       def to_onesky_locale(locale)

--- a/lib/onesky/rails/file_client.rb
+++ b/lib/onesky/rails/file_client.rb
@@ -28,8 +28,11 @@ NOTICE
         end
       end
 
-      def download(string_path)
-        verify_languages!
+      def download(string_path, options = {})
+        options[:base_only] ||= false
+        options[:all] ||= false
+
+        verify_languages!(base_only: options[:base_only], all: options[:all])
 
         files = get_default_locale_files(string_path).map {|path| File.basename(path)}
 

--- a/lib/tasks/onesky.rake
+++ b/lib/tasks/onesky.rake
@@ -1,25 +1,39 @@
 namespace :onesky do
-
-  desc "Upload string files of base locale to OneSky platform."
+  desc 'Upload string files of base locale to OneSky platform.'
   task :upload => :environment do
     file_client.upload(locale_path)
     puts 'Done!'
   end
 
-  desc "Download translations from OneSky platform."
+  desc 'Download translations from OneSky platform.'
   task :download => :environment do
     file_client.download(locale_path)
     puts 'Done!'
   end
 
+  desc 'Download base language translations from OneSky platform.'
+  task :download_base => :environment do
+    file_client.download(locale_path, base_only: true)
+    puts 'Done!'
+  end
+
+  desc 'Download all languages translations from OneSky platform.'
+  task :download_all => :environment do
+    file_client.download(locale_path, all: true)
+    puts 'Done!'
+  end
+
   def file_client
     require 'erb'
-    data = YAML::load(ERB.new(File.read(Rails.root.join('config', 'onesky.yml'))).result)
+    data = YAML::load(ERB.new(open_config_file).result)
     Onesky::Rails::FileClient.new data
   end
 
-  def locale_path
-    Rails.root.join("config/locales")
+  def open_config_file
+    File.read(Rails.root.join('config', 'onesky.yml'))
   end
 
+  def locale_path
+    Rails.root.join('config/locales')
+  end
 end


### PR DESCRIPTION
This PR adds 2 new Rake tasks:

```
rake onesky:download_base
```
Download translations of files uploaded only for the base language.

```
rake onesky:download_all
```
Download translations of files uploaded for all the languages including the base language.
